### PR TITLE
Added - [Header] Children prop to terra-clinical-header

### DIFF
--- a/kaiju/CollapsibleMenuViewDivider.json
+++ b/kaiju/CollapsibleMenuViewDivider.json
@@ -1,7 +1,7 @@
 {
   "name": "Divider",
   "library": "terra-collapsible-menu-view",
-  "display": "Menu divider",
+  "display": "Collapsible Menu divider",
   "description": "A dividing line between menu items",
   "group": "Molecules::Collapsible Menu View",
   "import": "CollapsibleMenuView",

--- a/kaiju/CollapsibleMenuViewGroup.json
+++ b/kaiju/CollapsibleMenuViewGroup.json
@@ -1,7 +1,7 @@
 {
   "name": "ItemGroup",
   "library": "terra-collapsible-menu-view",
-  "display": "Menu group",
+  "display": "Collapsible Menu group",
   "description": "A collapsing menu group",
   "group": "Molecules::Collapsible Menu View",
   "import": "CollapsibleMenuView",

--- a/kaiju/CollapsibleMenuViewItem.json
+++ b/kaiju/CollapsibleMenuViewItem.json
@@ -1,7 +1,7 @@
 {
   "name": "Item",
   "library": "terra-collapsible-menu-view",
-  "display": "Menu Item",
+  "display": "Collapsible Menu Item",
   "description": "A collapsing menu item",
   "group": "Molecules::Collapsible Menu View",
   "import": "CollapsibleMenuView",

--- a/kaiju/CollapsibleMenuViewToggle.json
+++ b/kaiju/CollapsibleMenuViewToggle.json
@@ -1,7 +1,7 @@
 {
   "name": "Toggle",
   "library": "terra-collapsible-menu-view",
-  "display": "Menu Toggle",
+  "display": "Collapsible Menu Toggle",
   "description": "A collapsing menu toggle",
   "group": "Molecules::Collapsible Menu View",
   "import": "CollapsibleMenuView",

--- a/kaiju/Header.json
+++ b/kaiju/Header.json
@@ -22,10 +22,7 @@
       "drop_zone": false
     },
     "children": {
-      "type": "Array",
-      "schema": {
-        "type": "Component"
-      }
+      "type": "Component"
     }
   }
 }

--- a/kaiju/Header.json
+++ b/kaiju/Header.json
@@ -20,6 +20,12 @@
     "endContent": {
       "type": "Component",
       "drop_zone": false
+    },
+    "children": {
+      "type": "Array",
+      "schema": {
+        "type": "Component"
+      }
     }
   }
 }


### PR DESCRIPTION
### Summary
#### Added
- children prop to terra-clinical-header

#### Updated
- Collapsible Menu View items displays to include "Collapsible" so they are searchable. 

Thanks for contributing to terra-kaiju-plugin.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
