### PR TITLE
Added - Footer to the Content Container

### DIFF
--- a/kaiju/ContentContainer.json
+++ b/kaiju/ContentContainer.json
@@ -5,6 +5,9 @@
   "description": "A structural component for arranging content with a header",
   "group": "Molecules::Other",
   "properties": {
+    "fill": {
+      "type": "Bool"
+    },
     "header": {
       "type": "Component"
     },
@@ -14,8 +17,12 @@
         "type": "Component"
       }
     },
-    "fill": {
-      "type": "Bool"
+    "footer": {
+      "type": "Array",
+      "schema": {
+        "type": "Component",
+        "drop_zone": false
+      }
     }
   }
 }

--- a/kaiju/Header.json
+++ b/kaiju/Header.json
@@ -22,7 +22,8 @@
       "drop_zone": false
     },
     "children": {
-      "type": "Component"
+      "type": "Component",
+      "drop_zone": false
     }
   }
 }


### PR DESCRIPTION
### Summary
Adds a footer to the ContentContainer

### Additional Details
This can be tested [here](https://kaiju-deployed-pr-67.herokuapp.com/)

This pull request also removes the drop zone placeholder for the header

Thanks for contributing to terra-kaiju-plugin.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
