### PR TITLE
Updated - [Heading] Added a default size with no value

### DIFF
--- a/kaiju/Fieldset.json
+++ b/kaiju/Fieldset.json
@@ -6,10 +6,6 @@
   "group": "Atoms::Forms",
   "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-fieldset/index",
   "properties": {
-    "isInline": {
-      "type": "Bool",
-      "display": "Inline"
-    },
     "required": {
       "type": "Bool"
     },

--- a/kaiju/Heading.json
+++ b/kaiju/Heading.json
@@ -46,8 +46,13 @@
     "size": {
       "type": "String",
       "form_type": "CodifiedList",
-      "default": "medium",
+      "default": "default",
       "options": [
+        {
+          "display": "default",
+          "value": "",
+          "type": "String"
+        },
         {
           "display": "Mini",
           "value": "mini",

--- a/kaiju/LoadingOverlay.json
+++ b/kaiju/LoadingOverlay.json
@@ -21,7 +21,7 @@
     },
     "message": {
       "type": "String",
-      "default": "loading..."
+      "default": "Loading..."
     },
     "backgroundStyle": {
       "type": "String",


### PR DESCRIPTION
### Summary
This changes the default size of the heading to have no value. If a size is specified the heading tags will always honor the set size instead of honoring the default values for h1-h6.

### Additional details

- Removed inline prop from fieldset
- Updated default loading message for Overlay. Fixes https://github.com/cerner/kaiju/issues/127

Thanks for contributing to terra-kaiju-plugin.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
