### PR TITLE
Updated - Documentation links

### DIFF
--- a/kaiju/ActionHeader.json
+++ b/kaiju/ActionHeader.json
@@ -4,7 +4,7 @@
   "display": "Action Header",
   "description": "A Header with actionable navigation buttons",
   "group": "Organisms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/action-header/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-action-header/clinical-action-header",
   "properties": {
     "title": {
       "type": "String",

--- a/kaiju/Alert.json
+++ b/kaiju/Alert.json
@@ -4,7 +4,7 @@
   "display": "Alert",
   "description": "Provides a styled notification to the user",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/alert/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-alert/alert",
   "properties": {
     "title": {
       "type": "String"

--- a/kaiju/Arrange.json
+++ b/kaiju/Arrange.json
@@ -4,7 +4,7 @@
   "display": "Arrange",
   "description": "A flexible container for aligning start, fill, and end content",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/arrange/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-arrange/arrange",
   "properties": {
     "fitStart": {
       "type": "Component",

--- a/kaiju/Avatar.json
+++ b/kaiju/Avatar.json
@@ -4,7 +4,7 @@
   "display": "Avatar",
   "description": "A circular frame to diplay an image or text",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/avatar/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-avatar/avatar",
   "properties": {
     "alt": {
       "type": "String"

--- a/kaiju/Badge.json
+++ b/kaiju/Badge.json
@@ -4,7 +4,7 @@
   "display": "Badge",
   "description": "Displays content classification",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/badge/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-badge/badge",
   "properties": {
     "isReversed": {
       "type": "Bool",

--- a/kaiju/Base.json
+++ b/kaiju/Base.json
@@ -4,7 +4,7 @@
   "display": "Base",
   "description": "Provides global style and translation support",
   "group": "Organisms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/base/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-base/base",
   "hidden": true,
   "properties": {
     "children": {

--- a/kaiju/Button.json
+++ b/kaiju/Button.json
@@ -4,7 +4,7 @@
   "display": "Button",
   "description": "Provides a way to trigger actions in the UI",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/button/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-button/button",
   "properties": {
     "isBlock": {
       "type": "Bool",

--- a/kaiju/ButtonGroup.json
+++ b/kaiju/ButtonGroup.json
@@ -4,7 +4,7 @@
   "display": "Button Group",
   "description": "Groups buttons and maintains a toggle selection state",
   "group": "Molecules::Button Group",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/button-group/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-button-group/button-group",
   "properties": {
     "children": {
       "type": "Array",

--- a/kaiju/ButtonGroupButton.json
+++ b/kaiju/ButtonGroupButton.json
@@ -5,7 +5,7 @@
   "description": "A Button Group Button",
   "group": "Molecules::Button Group",
   "import": "ButtonGroup",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/button-group/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-button-group/button-group",
   "properties": {
     "isDisabled": {
       "type": "Bool",

--- a/kaiju/Card.json
+++ b/kaiju/Card.json
@@ -4,7 +4,7 @@
   "display": "Card",
   "description": "Simple container for content",
   "group": "Atoms::Card",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/card/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-card/card",
   "properties": {
     "children": {
       "type": "Array",

--- a/kaiju/CardBody.json
+++ b/kaiju/CardBody.json
@@ -5,7 +5,7 @@
   "description": "Padding container to be placed within a Card",
   "group": "Atoms::Card",
   "import": "Card",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/card/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-card/card",
   "properties": {
     "isContentCentered": {
       "type": "Bool",

--- a/kaiju/Checkbox.json
+++ b/kaiju/Checkbox.json
@@ -4,7 +4,7 @@
   "display": "Checkbox",
   "description": "An on/off toggle represented by a checkmark inside of a box to the left of a description",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-checkbox/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form-checkbox/form-checkbox",
   "properties": {
     "defaultChecked": {
       "type": "Bool"

--- a/kaiju/CollapsibleMenuView.json
+++ b/kaiju/CollapsibleMenuView.json
@@ -4,7 +4,7 @@
   "display": "Collapsible Menu View",
   "description": "Collection of collapsible menu items",
   "group": "Molecules::Collapsible Menu View",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/collapsible-menu-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-collapsible-menu-view/collapsible-menu-view",
   "properties": {
     "menuWidth": {
       "type": "String",

--- a/kaiju/CollapsibleMenuViewDivider.json
+++ b/kaiju/CollapsibleMenuViewDivider.json
@@ -5,6 +5,6 @@
   "description": "A dividing line between menu items",
   "group": "Molecules::Collapsible Menu View",
   "import": "CollapsibleMenuView",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/collapsible-menu-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-collapsible-menu-view/collapsible-menu-view",
   "properties": {}
 }

--- a/kaiju/CollapsibleMenuViewGroup.json
+++ b/kaiju/CollapsibleMenuViewGroup.json
@@ -5,7 +5,7 @@
   "description": "A collapsing menu group",
   "group": "Molecules::Collapsible Menu View",
   "import": "CollapsibleMenuView",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/collapsible-menu-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-collapsible-menu-view/collapsible-menu-view",
   "properties": {
     "isSelectable": {
       "type": "Bool"

--- a/kaiju/CollapsibleMenuViewItem.json
+++ b/kaiju/CollapsibleMenuViewItem.json
@@ -5,7 +5,7 @@
   "description": "A collapsing menu item",
   "group": "Molecules::Collapsible Menu View",
   "import": "CollapsibleMenuView",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/collapsible-menu-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-collapsible-menu-view/collapsible-menu-view",
   "properties": {
     "isIconOnly": {
       "type": "Bool"

--- a/kaiju/CollapsibleMenuViewToggle.json
+++ b/kaiju/CollapsibleMenuViewToggle.json
@@ -5,7 +5,7 @@
   "description": "A collapsing menu toggle",
   "group": "Molecules::Collapsible Menu View",
   "import": "CollapsibleMenuView",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/collapsible-menu-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-collapsible-menu-view/collapsible-menu-view",
   "properties": {
     "isSelected": {
       "type": "Bool"

--- a/kaiju/ContentContainer.json
+++ b/kaiju/ContentContainer.json
@@ -4,7 +4,7 @@
   "display": "Content Container",
   "description": "A structural component for arranging content with a header",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/content-container/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-content-container/content-container",
   "properties": {
     "fill": {
       "type": "Bool"

--- a/kaiju/DatePicker.json
+++ b/kaiju/DatePicker.json
@@ -4,7 +4,7 @@
   "display": "Date Picker",
   "description": "A controlled input component for selecting dates",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/date-picker/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-date-picker/date-picker",
   "properties": {
     "isDisabled": {
       "type": "Bool",

--- a/kaiju/DateTimePicker.json
+++ b/kaiju/DateTimePicker.json
@@ -4,7 +4,7 @@
   "display": "Date Time Picker",
   "description": "A controlled input component for selecting a date and time",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/date-time-picker/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-date-time-picker/date-time-picker",
   "properties": {
     "disabled": {
       "type": "Bool"

--- a/kaiju/DemographicsBanner.json
+++ b/kaiju/DemographicsBanner.json
@@ -4,7 +4,7 @@
   "display": "Demographics Banner",
   "description": "Displays condensed demographic information",
   "group": "Organisms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/demographics-banner/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-demographics-banner/demographics-banner",
   "properties": {
     "personName": {
       "type": "String",

--- a/kaiju/DetailList.json
+++ b/kaiju/DetailList.json
@@ -5,7 +5,7 @@
   "description": "Displays a list of details",
   "group": "Templates::DetailView",
   "import": "DetailView",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/detail-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-detail-view/clinical-detail-view",
   "properties": {
     "title": {
       "type": "String",

--- a/kaiju/DetailListItem.json
+++ b/kaiju/DetailListItem.json
@@ -5,7 +5,7 @@
   "description": "Detail list item",
   "group": "Templates::DetailView",
   "import": "DetailView",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/detail-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-detail-view/clinical-detail-view",
   "properties": {
     "item": {
       "type": "Component"

--- a/kaiju/DetailView.json
+++ b/kaiju/DetailView.json
@@ -4,7 +4,7 @@
   "display": "Detail View",
   "description": "Displays text at different levels of importance",
   "group": "Templates::DetailView",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/detail-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-detail-view/clinical-detail-view",
   "properties": {
     "title": {
       "type": "String",

--- a/kaiju/Dialog.json
+++ b/kaiju/Dialog.json
@@ -4,7 +4,7 @@
   "display": "Dialog",
   "description": "A presentational layout for presenting alerts or actions",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/dialog/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-dialog/dialog",
   "properties": {
     "header": {
       "type": "Array",

--- a/kaiju/Divider.json
+++ b/kaiju/Divider.json
@@ -4,6 +4,6 @@
   "display": "Divider",
   "description": "A divider to separate content",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/divider/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-divider/divider",
   "properties": {}
 }

--- a/kaiju/Field.json
+++ b/kaiju/Field.json
@@ -4,7 +4,7 @@
   "display": "Field",
   "description": "A form container for arranging error, help, label, and value text",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-field/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form-field/form-field",
   "properties": {
     "isInline": {
       "type": "Bool",

--- a/kaiju/Fieldset.json
+++ b/kaiju/Fieldset.json
@@ -4,7 +4,7 @@
   "display": "Fieldset",
   "description": "A form layout for error, help, label, legend, and value text",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-fieldset/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form-fieldset/form-fieldset",
   "properties": {
     "required": {
       "type": "Bool"

--- a/kaiju/Grid.json
+++ b/kaiju/Grid.json
@@ -4,7 +4,7 @@
   "display": "Grid",
   "description": "Provides a flexbox based grid layout",
   "group": "Organisms::Grid",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/grid/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-grid/grid",
   "properties": {
     "children": {
       "type": "Array",

--- a/kaiju/GridColumn.json
+++ b/kaiju/GridColumn.json
@@ -5,7 +5,7 @@
   "description": "A grid column",
   "group": "Organisms::Grid",
   "import": "Grid",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/grid/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-grid/grid",
   "properties": {
     "col": {
       "type": "Number",

--- a/kaiju/GridRow.json
+++ b/kaiju/GridRow.json
@@ -5,7 +5,7 @@
   "description": "A grid row",
   "group": "Organisms::Grid",
   "import": "Grid",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/grid/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-grid/grid",
   "properties": {
     "children": {
       "type": "Array",

--- a/kaiju/Header.json
+++ b/kaiju/Header.json
@@ -4,7 +4,7 @@
   "display": "Header",
   "description": "Arranges a title and content within a Header",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/header/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-header/clinical-header",
   "properties": {
     "title": {
       "type": "String",

--- a/kaiju/Heading.json
+++ b/kaiju/Heading.json
@@ -4,7 +4,7 @@
   "display": "Heading",
   "description": "Provides standard heading styles ( h1-h6 )",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/heading/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-heading/heading",
   "properties": {
     "level": {
       "type": "Number",

--- a/kaiju/Image.json
+++ b/kaiju/Image.json
@@ -4,7 +4,7 @@
   "display": "Image",
   "description": "Provides a flexible image container",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/image/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-image/image",
   "properties": {
     "src": {
       "type": "String",

--- a/kaiju/Input.json
+++ b/kaiju/Input.json
@@ -3,7 +3,7 @@
   "library": "terra-form-input",
   "display": "Input",
   "description": "Input form element",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-input/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form-input/form-input",
   "group": "Atoms::Forms",
   "properties": {
     "required": {

--- a/kaiju/ItemCollection.json
+++ b/kaiju/ItemCollection.json
@@ -4,7 +4,7 @@
   "display": "Item Collection",
   "description": "Responsively displays data as a table or a list",
   "group": "Molecules::Item Collection",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/item-collection/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-item-collection/clinical-item-collection",
   "properties": {
     "numberOfDisplays": {
       "type": "Number",

--- a/kaiju/ItemCollectionComment.json
+++ b/kaiju/ItemCollectionComment.json
@@ -5,7 +5,7 @@
   "description": "An item collection comment",
   "group": "Molecules::Item Collection",
   "import": "ItemCollection",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/item-collection/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-item-collection/clinical-item-collection",
   "properties": {
     "isTruncated": {
       "type": "Bool",

--- a/kaiju/ItemCollectionDisplay.json
+++ b/kaiju/ItemCollectionDisplay.json
@@ -5,7 +5,7 @@
   "description": "An item collection display",
   "group": "Molecules::Item Collection",
   "import": "ItemCollection",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/item-collection/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-item-collection/clinical-item-collection",
   "properties": {
     "isTruncated": {
       "type": "Bool",

--- a/kaiju/ItemCollectionItem.json
+++ b/kaiju/ItemCollectionItem.json
@@ -5,7 +5,7 @@
   "description": "A collection item",
   "group": "Molecules::Item Collection",
   "import": "ItemCollection",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/item-collection/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-item-collection/clinical-item-collection",
   "properties": {
     "startAccessory": {
       "type": "Component",

--- a/kaiju/ItemDisplay.json
+++ b/kaiju/ItemDisplay.json
@@ -4,7 +4,7 @@
   "display": "Item Display",
   "description": "An ItemView text display with an optional icon",
   "group": "Molecules::Item View",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/item-display/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-item-display/clinical-item-display",
   "properties": {
     "isTruncated": {
       "type": "Bool",

--- a/kaiju/ItemDisplayComment.json
+++ b/kaiju/ItemDisplayComment.json
@@ -5,7 +5,7 @@
   "description": "A styled ItemView comment display and icon",
   "group": "Molecules::Item View",
   "import": "ItemDisplay",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/item-display/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-item-display/clinical-item-display",
   "properties": {
     "isTruncated": {
       "type": "Bool",

--- a/kaiju/ItemView.json
+++ b/kaiju/ItemView.json
@@ -4,7 +4,7 @@
   "display": "Item View",
   "description": "Organizes displays into rows and columns with optional start and end accessory elements",
   "group": "Molecules::Item View",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/item-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-item-view/clinical-item-view",
   "properties": {
     "isTruncated": {
       "type": "Bool"

--- a/kaiju/LabelValueView.json
+++ b/kaiju/LabelValueView.json
@@ -4,7 +4,7 @@
   "display": "Label Value View",
   "description": "Displays a label and associated value",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/clinical/site/label-value-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-clinical-label-value-view/clinical-label-value-view",
   "properties": {
     "label": {
       "type": "String",

--- a/kaiju/List.json
+++ b/kaiju/List.json
@@ -4,7 +4,7 @@
   "display": "List",
   "description": "A list",
   "group": "Organisms::List",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/list/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-list/list",
   "properties": {
     "isDivided": {
       "type": "Bool",

--- a/kaiju/ListItem.json
+++ b/kaiju/ListItem.json
@@ -5,7 +5,7 @@
   "description": "A list item for managing selections and chevrons",
   "group": "Organisms::List",
   "import": "List",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/list/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-list/list",
   "properties": {
     "isSelected": {
       "type": "Bool",

--- a/kaiju/LoadingOverlay.json
+++ b/kaiju/LoadingOverlay.json
@@ -5,7 +5,7 @@
   "description": "A semi-transparent loading overlay to block UI interactions",
   "group": "Molecules::Overlay",
   "import_from": "terra-overlay/lib/LoadingOverlay",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/overlay/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-overlay/overlay",
   "properties": {
     "isOpen": {
       "type": "Bool",

--- a/kaiju/MultiSelectList.json
+++ b/kaiju/MultiSelectList.json
@@ -5,7 +5,7 @@
   "description": "A list for managing multiple selections",
   "group": "Organisms::List",
   "import_from": "terra-list/lib/MultiSelectList",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/list/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-list/list",
   "properties": {
     "isDivided": {
       "type": "Bool",

--- a/kaiju/NumberField.json
+++ b/kaiju/NumberField.json
@@ -5,7 +5,7 @@
   "description": "Provides a standard Number Input with an optional label, error, and help property",
   "group": "Molecules::Forms",
   "import_from": "terra-form/lib/NumberField",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form/form",
   "properties": {
     "value": {
       "type": "String"

--- a/kaiju/Overlay.json
+++ b/kaiju/Overlay.json
@@ -5,7 +5,7 @@
   "description": "A semi-transparent overlay to block UI interactions",
   "group": "Molecules::Overlay",
   "import_from": "terra-overlay/lib/Overlay",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/overlay/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-overlay/overlay",
   "properties": {
     "isOpen": {
       "type": "Bool",

--- a/kaiju/OverlayContainer.json
+++ b/kaiju/OverlayContainer.json
@@ -5,7 +5,7 @@
   "description": "A semi-transparent overlay to block UI interactions within restricted content region",
   "group": "Molecules::Overlay",
   "import_from": "terra-overlay/lib/OverlayContainer",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/overlay/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-overlay/overlay",
   "properties": {
     "children": {
       "type": "Array",

--- a/kaiju/ProgressBar.json
+++ b/kaiju/ProgressBar.json
@@ -4,7 +4,7 @@
   "display": "Progress Bar",
   "description": "Display the progress of a process",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/progress-bar/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-progress-bar/progress-bar",
   "properties": {
     "color": {
       "type": "String"

--- a/kaiju/Radio.json
+++ b/kaiju/Radio.json
@@ -4,7 +4,7 @@
   "display": "Radio",
   "description": "A control element that allows the user to choose only one of a predefined set of mutually exclusive options",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-radio/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form-radio/form-radio",
   "properties": {
     "defaultChecked": {
       "type": "Bool"

--- a/kaiju/ResponsiveElement.json
+++ b/kaiju/ResponsiveElement.json
@@ -4,7 +4,7 @@
   "display": "Responsive Element",
   "description": "Conditionally renders components based on viewport size",
   "group": "Organisms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/responsive-element/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-responsive-element/responsive-element",
   "properties": {
     "responsiveTo": {
       "type": "String",

--- a/kaiju/SearchField.json
+++ b/kaiju/SearchField.json
@@ -4,7 +4,7 @@
   "display": "Search Field",
   "description": "A styled search input with a debounce callback",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/search-field/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-search-field/search-field",
   "properties": {
     "isBlock": {
       "type": "Bool",

--- a/kaiju/SectionHeader.json
+++ b/kaiju/SectionHeader.json
@@ -4,7 +4,7 @@
   "display": "Section Header",
   "description": "Presentational header for distinguishing sections",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/section-header/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-section-header/section-header",
   "properties": {
     "title": {
       "type": "String",

--- a/kaiju/Select.json
+++ b/kaiju/Select.json
@@ -4,7 +4,7 @@
   "display": "Select",
   "description": "A dropdown of selectable options",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-select/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form-select/form-select",
   "properties": {
     "isInvalid": {
       "type": "Bool",

--- a/kaiju/SelectOption.json
+++ b/kaiju/SelectOption.json
@@ -5,7 +5,7 @@
   "description": "A select option",
   "import": "Select",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-select/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form-select/form-select",
   "properties": {
     "value": {
       "type": "String"

--- a/kaiju/Signature.json
+++ b/kaiju/Signature.json
@@ -4,7 +4,7 @@
   "display": "Signature",
   "description": "A customizable signature",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/signature/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-signature/signature",
   "properties": {
     "lineWidth": {
       "type": "Number",

--- a/kaiju/SingleSelectList.json
+++ b/kaiju/SingleSelectList.json
@@ -5,7 +5,7 @@
   "description": "A list for managing a single selection",
   "group": "Organisms::List",
   "import_from": "terra-list/lib/SingleSelectList",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/list/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-list/list",
   "properties": {
     "hasChevrons": {
       "type": "Bool",

--- a/kaiju/SlidePanel.json
+++ b/kaiju/SlidePanel.json
@@ -4,7 +4,7 @@
   "display": "Slide Panel",
   "description": "A progessive disclosure mechanism for content",
   "group": "Organisms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/slide-panel/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-slide-panel/slide-panel",
   "properties": {
     "mainContent": {
       "type": "Component"

--- a/kaiju/Spacer.json
+++ b/kaiju/Spacer.json
@@ -4,7 +4,7 @@
   "display": "Spacer",
   "description": "Adds margins and padding",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/spacer/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-spacer/spacer",
   "properties": {
     "isInlineBlock": {
       "type": "Bool",

--- a/kaiju/Status.json
+++ b/kaiju/Status.json
@@ -4,7 +4,7 @@
   "display": "Status",
   "description": "A customizable color indictor to signify a specific condition",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/status/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-status/status",
   "properties": {
     "color": {
       "type": "String",

--- a/kaiju/StatusView.json
+++ b/kaiju/StatusView.json
@@ -4,7 +4,7 @@
   "display": "Status View",
   "description": "General purpose status indicator for content",
   "group": "Templates::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/status-view/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-status-view/status-view",
   "properties": {
     "isAlignedTop": {
       "type": "Bool",

--- a/kaiju/Table.json
+++ b/kaiju/Table.json
@@ -4,7 +4,7 @@
   "display": "Table",
   "description": "Structural table",
   "group": "Organisms::Table",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/table/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-table/table",
   "properties": {
     "isStriped": {
       "type": "Bool",

--- a/kaiju/TableCell.json
+++ b/kaiju/TableCell.json
@@ -5,7 +5,7 @@
   "description": "A table cell",
   "group": "Organisms::Table",
   "import": "Table",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/table/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-table/table",
   "properties": {
     "content": {
       "type": "Component"

--- a/kaiju/TableHeader.json
+++ b/kaiju/TableHeader.json
@@ -5,7 +5,7 @@
   "description": "A table header",
   "group": "Organisms::Table",
   "import": "Table",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/table/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-table/table",
   "properties": {
     "children": {
       "type": "Array",

--- a/kaiju/TableHeaderCell.json
+++ b/kaiju/TableHeaderCell.json
@@ -5,7 +5,7 @@
   "description": "A table header cell",
   "group": "Organisms::Table",
   "import": "Table",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/table/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-table/table",
   "properties": {
     "minWidth": {
       "type": "String",

--- a/kaiju/TableRow.json
+++ b/kaiju/TableRow.json
@@ -5,7 +5,7 @@
   "description": "A table row",
   "group": "Organisms::Table",
   "import": "Table",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/table/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-table/table",
   "properties": {
     "isSelected": {
       "type": "Bool",

--- a/kaiju/TableRows.json
+++ b/kaiju/TableRows.json
@@ -5,7 +5,7 @@
   "description": "Table rows",
   "group": "Organisms::Table",
   "import": "Table",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/table/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-table/table",
   "properties": {
     "children": {
       "type": "Array",

--- a/kaiju/TableSubHeader.json
+++ b/kaiju/TableSubHeader.json
@@ -5,7 +5,7 @@
   "description": "A table subheader",
   "group": "Organisms::Table",
   "import": "Table",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/table/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-table/table",
   "properties": {
     "colSpan": {
       "type": "Number",

--- a/kaiju/Tabs.json
+++ b/kaiju/Tabs.json
@@ -4,7 +4,7 @@
   "display": "Tabs",
   "description": "Container for organizing content",
   "group": "Molecules::Tabs",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/tabs/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-tabs/tabs",
   "properties": {
     "tabFill": {
       "type": "Bool"

--- a/kaiju/TabsPane.json
+++ b/kaiju/TabsPane.json
@@ -5,7 +5,7 @@
   "description": "Tab content",
   "group": "Molecules::Tabs",
   "import": "Tabs",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/tabs/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-tabs/tabs",
   "properties": {
     "isDisabled": {
       "type": "Bool",

--- a/kaiju/Tag.json
+++ b/kaiju/Tag.json
@@ -4,7 +4,7 @@
   "display": "Tag",
   "description": "An actionable tag",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/tag/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-tag/tag",
   "properties": {
     "href": {
       "type": "String"

--- a/kaiju/Text.json
+++ b/kaiju/Text.json
@@ -4,7 +4,7 @@
   "display": "Text Component",
   "description": "Component for displaying customizable text in UI",
   "group": "Atoms::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/text/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-text/text",
   "properties": {
     "color": {
       "type": "String"

--- a/kaiju/Textarea.json
+++ b/kaiju/Textarea.json
@@ -4,7 +4,7 @@
   "display": "Textarea",
   "description": "A text area",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/form-textarea/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-form-textarea/form-textarea",
   "properties": {
     "required": {
       "type": "Bool"

--- a/kaiju/TimeInput.json
+++ b/kaiju/TimeInput.json
@@ -4,7 +4,7 @@
   "display": "Time Input",
   "description": "A controlled input for time entry",
   "group": "Atoms::Forms",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/time-input/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-time-input/time-input",
   "properties": {
     "name": {
       "type": "String",

--- a/kaiju/Toggle.json
+++ b/kaiju/Toggle.json
@@ -4,7 +4,7 @@
   "display": "Toggle",
   "description": "A disclosure mechanism for showing and hiding content in an animated fashion",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/toggle/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-toggle/toggle",
   "properties": {
     "isOpen": {
       "type": "Bool",

--- a/kaiju/ToggleButton.json
+++ b/kaiju/ToggleButton.json
@@ -4,7 +4,7 @@
   "display": "Toggle Button",
   "description": "A disclosure mechanism for showing and hiding content in an animated fashion by interacting with a Button",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/toggle-button/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-toggle-button/toggle-button",
   "properties": {
     "isInitiallyOpen": {
       "type": "Bool",

--- a/kaiju/ToggleSectionHeader.json
+++ b/kaiju/ToggleSectionHeader.json
@@ -4,7 +4,7 @@
   "display": "Toggle Section Header",
   "description": "Interactable section for collapsing content",
   "group": "Molecules::Other",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/toggle-section-header/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-toggle-section-header/toggle-section-header",
   "properties": {
     "isAnimated": {
       "type": "Bool",

--- a/kaiju/icons/IconAbnormal.json
+++ b/kaiju/icons/IconAbnormal.json
@@ -5,7 +5,7 @@
   "description": "Abnormal Icon",
   "import_from": "terra-icon/lib/icon/IconAbnormal",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAdd.json
+++ b/kaiju/icons/IconAdd.json
@@ -5,7 +5,7 @@
   "description": "Add Icon",
   "import_from": "terra-icon/lib/icon/IconAdd",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAddPerson.json
+++ b/kaiju/icons/IconAddPerson.json
@@ -5,7 +5,7 @@
   "description": "Add Person Icon",
   "import_from": "terra-icon/lib/icon/IconAddPerson",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAlert.json
+++ b/kaiju/icons/IconAlert.json
@@ -5,7 +5,7 @@
   "description": "Alert Icon",
   "import_from": "terra-icon/lib/icon/IconAlert",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAllergy.json
+++ b/kaiju/icons/IconAllergy.json
@@ -5,7 +5,7 @@
   "description": "Allergy Icon",
   "import_from": "terra-icon/lib/icon/IconAllergy",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAnalytics.json
+++ b/kaiju/icons/IconAnalytics.json
@@ -5,7 +5,7 @@
   "description": "Analytics Icon",
   "import_from": "terra-icon/lib/icon/IconAnalytics",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAnnouncement.json
+++ b/kaiju/icons/IconAnnouncement.json
@@ -5,7 +5,7 @@
   "description": "Announcement Icon",
   "import_from": "terra-icon/lib/icon/IconAnnouncement",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconArchive.json
+++ b/kaiju/icons/IconArchive.json
@@ -5,7 +5,7 @@
   "description": "Archive Icon",
   "import_from": "terra-icon/lib/icon/IconArchive",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAttachment.json
+++ b/kaiju/icons/IconAttachment.json
@@ -5,7 +5,7 @@
   "description": "Attachment Icon",
   "import_from": "terra-icon/lib/icon/IconAttachment",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAudio.json
+++ b/kaiju/icons/IconAudio.json
@@ -5,7 +5,7 @@
   "description": "Audio Icon",
   "import_from": "terra-icon/lib/icon/IconAudio",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAvailable.json
+++ b/kaiju/icons/IconAvailable.json
@@ -5,7 +5,7 @@
   "description": "Available Icon",
   "import_from": "terra-icon/lib/icon/IconAvailable",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconAway.json
+++ b/kaiju/icons/IconAway.json
@@ -5,7 +5,7 @@
   "description": "Away Icon",
   "import_from": "terra-icon/lib/icon/IconAway",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconBedAssigned.json
+++ b/kaiju/icons/IconBedAssigned.json
@@ -5,7 +5,7 @@
   "description": "Bed Assigned Icon",
   "import_from": "terra-icon/lib/icon/IconBedAssigned",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconBedRequested.json
+++ b/kaiju/icons/IconBedRequested.json
@@ -5,7 +5,7 @@
   "description": "Bed Requested Icon",
   "import_from": "terra-icon/lib/icon/IconBedRequested",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconBookmark.json
+++ b/kaiju/icons/IconBookmark.json
@@ -5,7 +5,7 @@
   "description": "Bookmark Icon",
   "import_from": "terra-icon/lib/icon/IconBookmark",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconBriefcase.json
+++ b/kaiju/icons/IconBriefcase.json
@@ -5,7 +5,7 @@
   "description": "Briefcase Icon",
   "import_from": "terra-icon/lib/icon/IconBriefcase",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconBusy.json
+++ b/kaiju/icons/IconBusy.json
@@ -5,7 +5,7 @@
   "description": "Busy Icon",
   "import_from": "terra-icon/lib/icon/IconBusy",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCalculator.json
+++ b/kaiju/icons/IconCalculator.json
@@ -5,7 +5,7 @@
   "description": "Calculator Icon",
   "import_from": "terra-icon/lib/icon/IconCalculator",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCalendar.json
+++ b/kaiju/icons/IconCalendar.json
@@ -5,7 +5,7 @@
   "description": "Calendar Icon",
   "import_from": "terra-icon/lib/icon/IconCalendar",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCamera.json
+++ b/kaiju/icons/IconCamera.json
@@ -5,7 +5,7 @@
   "description": "Camera Icon",
   "import_from": "terra-icon/lib/icon/IconCamera",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCancel.json
+++ b/kaiju/icons/IconCancel.json
@@ -5,7 +5,7 @@
   "description": "Cancel Icon",
   "import_from": "terra-icon/lib/icon/IconCancel",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCaretDown.json
+++ b/kaiju/icons/IconCaretDown.json
@@ -5,7 +5,7 @@
   "description": "Caret Down Icon",
   "import_from": "terra-icon/lib/icon/IconCaretDown",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCaretLeft.json
+++ b/kaiju/icons/IconCaretLeft.json
@@ -5,7 +5,7 @@
   "description": "Caret Left Icon",
   "import_from": "terra-icon/lib/icon/IconCaretLeft",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCaretRight.json
+++ b/kaiju/icons/IconCaretRight.json
@@ -5,7 +5,7 @@
   "description": "Caret Right Icon",
   "import_from": "terra-icon/lib/icon/IconCaretRight",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCaretUp.json
+++ b/kaiju/icons/IconCaretUp.json
@@ -5,7 +5,7 @@
   "description": "Caret Up Icon",
   "import_from": "terra-icon/lib/icon/IconCaretUp",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconChecklist.json
+++ b/kaiju/icons/IconChecklist.json
@@ -5,7 +5,7 @@
   "description": "Checklist Icon",
   "import_from": "terra-icon/lib/icon/IconChecklist",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCheckmark.json
+++ b/kaiju/icons/IconCheckmark.json
@@ -5,7 +5,7 @@
   "description": "Checkmark Icon",
   "import_from": "terra-icon/lib/icon/IconCheckmark",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconChevron.json
+++ b/kaiju/icons/IconChevron.json
@@ -5,7 +5,7 @@
   "description": "Chevron Icon",
   "import_from": "terra-icon/lib/icon/IconChevron",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconChevronDown.json
+++ b/kaiju/icons/IconChevronDown.json
@@ -5,7 +5,7 @@
   "description": "Chevron Down Icon",
   "import_from": "terra-icon/lib/icon/IconChevronDown",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconChevronLeft.json
+++ b/kaiju/icons/IconChevronLeft.json
@@ -5,7 +5,7 @@
   "description": "Chevron Left Icon",
   "import_from": "terra-icon/lib/icon/IconChevronLeft",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconChevronRight.json
+++ b/kaiju/icons/IconChevronRight.json
@@ -5,7 +5,7 @@
   "description": "Chevron Right Icon",
   "import_from": "terra-icon/lib/icon/IconChevronRight",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconChevronUp.json
+++ b/kaiju/icons/IconChevronUp.json
@@ -5,7 +5,7 @@
   "description": "Chevron Up Icon",
   "import_from": "terra-icon/lib/icon/IconChevronUp",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconClear.json
+++ b/kaiju/icons/IconClear.json
@@ -5,7 +5,7 @@
   "description": "Clear Icon",
   "import_from": "terra-icon/lib/icon/IconClear",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconClipboard.json
+++ b/kaiju/icons/IconClipboard.json
@@ -5,7 +5,7 @@
   "description": "Clipboard Icon",
   "import_from": "terra-icon/lib/icon/IconClipboard",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconClock.json
+++ b/kaiju/icons/IconClock.json
@@ -5,7 +5,7 @@
   "description": "Clock Icon",
   "import_from": "terra-icon/lib/icon/IconClock",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconClose.json
+++ b/kaiju/icons/IconClose.json
@@ -5,7 +5,7 @@
   "description": "Close Icon",
   "import_from": "terra-icon/lib/icon/IconClose",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconComment.json
+++ b/kaiju/icons/IconComment.json
@@ -5,7 +5,7 @@
   "description": "Comment Icon",
   "import_from": "terra-icon/lib/icon/IconComment",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCommit.json
+++ b/kaiju/icons/IconCommit.json
@@ -5,7 +5,7 @@
   "description": "Commit Icon",
   "import_from": "terra-icon/lib/icon/IconCommit",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconComplete.json
+++ b/kaiju/icons/IconComplete.json
@@ -5,7 +5,7 @@
   "description": "Complete Icon",
   "import_from": "terra-icon/lib/icon/IconComplete",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCompose.json
+++ b/kaiju/icons/IconCompose.json
@@ -5,7 +5,7 @@
   "description": "Compose Icon",
   "import_from": "terra-icon/lib/icon/IconCompose",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCritical.json
+++ b/kaiju/icons/IconCritical.json
@@ -5,7 +5,7 @@
   "description": "Critical Icon",
   "import_from": "terra-icon/lib/icon/IconCritical",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconCriticalInverse.json
+++ b/kaiju/icons/IconCriticalInverse.json
@@ -5,7 +5,7 @@
   "description": "Critical Inverse Icon",
   "import_from": "terra-icon/lib/icon/IconCriticalInverse",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDevice.json
+++ b/kaiju/icons/IconDevice.json
@@ -5,7 +5,7 @@
   "description": "Device Icon",
   "import_from": "terra-icon/lib/icon/IconDevice",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDeviceAlert.json
+++ b/kaiju/icons/IconDeviceAlert.json
@@ -5,7 +5,7 @@
   "description": "Device Alert Icon",
   "import_from": "terra-icon/lib/icon/IconDeviceAlert",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDeviceCheck.json
+++ b/kaiju/icons/IconDeviceCheck.json
@@ -5,7 +5,7 @@
   "description": "Device Check Icon",
   "import_from": "terra-icon/lib/icon/IconDeviceCheck",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDiamond.json
+++ b/kaiju/icons/IconDiamond.json
@@ -5,7 +5,7 @@
   "description": "Diamond Icon",
   "import_from": "terra-icon/lib/icon/IconDiamond",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDischargeComingDue.json
+++ b/kaiju/icons/IconDischargeComingDue.json
@@ -5,7 +5,7 @@
   "description": "Discharge Coming Due Icon",
   "import_from": "terra-icon/lib/icon/IconDischargeComingDue",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDischargeComplete.json
+++ b/kaiju/icons/IconDischargeComplete.json
@@ -5,7 +5,7 @@
   "description": "Discharge Complete Icon",
   "import_from": "terra-icon/lib/icon/IconDischargeComplete",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDischargeOverDue.json
+++ b/kaiju/icons/IconDischargeOverDue.json
@@ -5,7 +5,7 @@
   "description": "Discharge Over Due Icon",
   "import_from": "terra-icon/lib/icon/IconDischargeOverDue",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDoNotDisturb.json
+++ b/kaiju/icons/IconDoNotDisturb.json
@@ -5,7 +5,7 @@
   "description": "Do Not Disturb Icon",
   "import_from": "terra-icon/lib/icon/IconDoNotDisturb",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDocuments.json
+++ b/kaiju/icons/IconDocuments.json
@@ -5,7 +5,7 @@
   "description": "Documents Icon",
   "import_from": "terra-icon/lib/icon/IconDocuments",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDoorOpen.json
+++ b/kaiju/icons/IconDoorOpen.json
@@ -5,7 +5,7 @@
   "description": "Door Open Icon",
   "import_from": "terra-icon/lib/icon/IconDoorOpen",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDown.json
+++ b/kaiju/icons/IconDown.json
@@ -5,7 +5,7 @@
   "description": "Down Icon",
   "import_from": "terra-icon/lib/icon/IconDown",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDownload.json
+++ b/kaiju/icons/IconDownload.json
@@ -5,7 +5,7 @@
   "description": "Download Icon",
   "import_from": "terra-icon/lib/icon/IconDownload",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDue.json
+++ b/kaiju/icons/IconDue.json
@@ -5,7 +5,7 @@
   "description": "Due Icon",
   "import_from": "terra-icon/lib/icon/IconDue",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconDueSoon.json
+++ b/kaiju/icons/IconDueSoon.json
@@ -5,7 +5,7 @@
   "description": "Due Soon Icon",
   "import_from": "terra-icon/lib/icon/IconDueSoon",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconEdit.json
+++ b/kaiju/icons/IconEdit.json
@@ -5,7 +5,7 @@
   "description": "Edit Icon",
   "import_from": "terra-icon/lib/icon/IconEdit",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconEllipses.json
+++ b/kaiju/icons/IconEllipses.json
@@ -5,7 +5,7 @@
   "description": "Ellipses Icon",
   "import_from": "terra-icon/lib/icon/IconEllipses",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconEnvelope.json
+++ b/kaiju/icons/IconEnvelope.json
@@ -5,7 +5,7 @@
   "description": "Envelope Icon",
   "import_from": "terra-icon/lib/icon/IconEnvelope",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconError.json
+++ b/kaiju/icons/IconError.json
@@ -5,7 +5,7 @@
   "description": "Error Icon",
   "import_from": "terra-icon/lib/icon/IconError",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconErrorDark.json
+++ b/kaiju/icons/IconErrorDark.json
@@ -5,7 +5,7 @@
   "description": "Error Dark Icon",
   "import_from": "terra-icon/lib/icon/IconErrorDark",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconExclamation.json
+++ b/kaiju/icons/IconExclamation.json
@@ -5,7 +5,7 @@
   "description": "Exclamation Icon",
   "import_from": "terra-icon/lib/icon/IconExclamation",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconExpandLess.json
+++ b/kaiju/icons/IconExpandLess.json
@@ -5,7 +5,7 @@
   "description": "Expand Less Icon",
   "import_from": "terra-icon/lib/icon/IconExpandLess",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconExpandMore.json
+++ b/kaiju/icons/IconExpandMore.json
@@ -5,7 +5,7 @@
   "description": "Expand More Icon",
   "import_from": "terra-icon/lib/icon/IconExpandMore",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconExternalLink.json
+++ b/kaiju/icons/IconExternalLink.json
@@ -5,7 +5,7 @@
   "description": "External Link Icon",
   "import_from": "terra-icon/lib/icon/IconExternalLink",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFeatured.json
+++ b/kaiju/icons/IconFeatured.json
@@ -5,7 +5,7 @@
   "description": "Featured Icon",
   "import_from": "terra-icon/lib/icon/IconFeatured",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFeaturedOff.json
+++ b/kaiju/icons/IconFeaturedOff.json
@@ -5,7 +5,7 @@
   "description": "Featured Off Icon",
   "import_from": "terra-icon/lib/icon/IconFeaturedOff",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFeaturedOutline.json
+++ b/kaiju/icons/IconFeaturedOutline.json
@@ -5,7 +5,7 @@
   "description": "Featured Outline Icon",
   "import_from": "terra-icon/lib/icon/IconFeaturedOutline",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFirst.json
+++ b/kaiju/icons/IconFirst.json
@@ -5,7 +5,7 @@
   "description": "First Icon",
   "import_from": "terra-icon/lib/icon/IconFirst",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFlag.json
+++ b/kaiju/icons/IconFlag.json
@@ -5,7 +5,7 @@
   "description": "Flag Icon",
   "import_from": "terra-icon/lib/icon/IconFlag",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFlipHorizontal.json
+++ b/kaiju/icons/IconFlipHorizontal.json
@@ -5,7 +5,7 @@
   "description": "Flip Horizontal Icon",
   "import_from": "terra-icon/lib/icon/IconFlipHorizontal",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFlipVertical.json
+++ b/kaiju/icons/IconFlipVertical.json
@@ -5,7 +5,7 @@
   "description": "Flip Vertical Icon",
   "import_from": "terra-icon/lib/icon/IconFlipVertical",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFlowsheet.json
+++ b/kaiju/icons/IconFlowsheet.json
@@ -5,7 +5,7 @@
   "description": "Flowsheet Icon",
   "import_from": "terra-icon/lib/icon/IconFlowsheet",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFolder.json
+++ b/kaiju/icons/IconFolder.json
@@ -5,7 +5,7 @@
   "description": "Folder Icon",
   "import_from": "terra-icon/lib/icon/IconFolder",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconForward.json
+++ b/kaiju/icons/IconForward.json
@@ -5,7 +5,7 @@
   "description": "Forward Icon",
   "import_from": "terra-icon/lib/icon/IconForward",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconFunnel.json
+++ b/kaiju/icons/IconFunnel.json
@@ -5,7 +5,7 @@
   "description": "Funnel Icon",
   "import_from": "terra-icon/lib/icon/IconFunnel",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconGapChecking.json
+++ b/kaiju/icons/IconGapChecking.json
@@ -5,7 +5,7 @@
   "description": "Gap Checking Icon",
   "import_from": "terra-icon/lib/icon/IconGapChecking",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconGlasses.json
+++ b/kaiju/icons/IconGlasses.json
@@ -5,7 +5,7 @@
   "description": "Glasses Icon",
   "import_from": "terra-icon/lib/icon/IconGlasses",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconHelp.json
+++ b/kaiju/icons/IconHelp.json
@@ -5,7 +5,7 @@
   "description": "Help Icon",
   "import_from": "terra-icon/lib/icon/IconHelp",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconHelpInverse.json
+++ b/kaiju/icons/IconHelpInverse.json
@@ -5,7 +5,7 @@
   "description": "Help Inverse Icon",
   "import_from": "terra-icon/lib/icon/IconHelpInverse",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconHigh.json
+++ b/kaiju/icons/IconHigh.json
@@ -5,7 +5,7 @@
   "description": "High Icon",
   "import_from": "terra-icon/lib/icon/IconHigh",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconHighInverse.json
+++ b/kaiju/icons/IconHighInverse.json
@@ -5,7 +5,7 @@
   "description": "High Inverse Icon",
   "import_from": "terra-icon/lib/icon/IconHighInverse",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconHighPriority.json
+++ b/kaiju/icons/IconHighPriority.json
@@ -5,7 +5,7 @@
   "description": "High Priority Icon",
   "import_from": "terra-icon/lib/icon/IconHighPriority",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconHold.json
+++ b/kaiju/icons/IconHold.json
@@ -5,7 +5,7 @@
   "description": "Hold Icon",
   "import_from": "terra-icon/lib/icon/IconHold",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconHospital.json
+++ b/kaiju/icons/IconHospital.json
@@ -5,7 +5,7 @@
   "description": "Hospital Icon",
   "import_from": "terra-icon/lib/icon/IconHospital",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconHouse.json
+++ b/kaiju/icons/IconHouse.json
@@ -5,7 +5,7 @@
   "description": "House Icon",
   "import_from": "terra-icon/lib/icon/IconHouse",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconIPass.json
+++ b/kaiju/icons/IconIPass.json
@@ -5,7 +5,7 @@
   "description": "I Pass Icon",
   "import_from": "terra-icon/lib/icon/IconIPass",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconImage.json
+++ b/kaiju/icons/IconImage.json
@@ -5,7 +5,7 @@
   "description": "Image Icon",
   "import_from": "terra-icon/lib/icon/IconImage",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconImplant.json
+++ b/kaiju/icons/IconImplant.json
@@ -5,7 +5,7 @@
   "description": "Implant Icon",
   "import_from": "terra-icon/lib/icon/IconImplant",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconIncomingCall.json
+++ b/kaiju/icons/IconIncomingCall.json
@@ -5,7 +5,7 @@
   "description": "Incoming Call Icon",
   "import_from": "terra-icon/lib/icon/IconIncomingCall",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconIncomplete.json
+++ b/kaiju/icons/IconIncomplete.json
@@ -5,7 +5,7 @@
   "description": "Incomplete Icon",
   "import_from": "terra-icon/lib/icon/IconIncomplete",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconInformation.json
+++ b/kaiju/icons/IconInformation.json
@@ -5,7 +5,7 @@
   "description": "Information Icon",
   "import_from": "terra-icon/lib/icon/IconInformation",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconInformationInverse.json
+++ b/kaiju/icons/IconInformationInverse.json
@@ -5,7 +5,7 @@
   "description": "Information Inverse Icon",
   "import_from": "terra-icon/lib/icon/IconInformationInverse",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconItalicI.json
+++ b/kaiju/icons/IconItalicI.json
@@ -5,7 +5,7 @@
   "description": "Italic I Icon",
   "import_from": "terra-icon/lib/icon/IconItalicI",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconKnurling.json
+++ b/kaiju/icons/IconKnurling.json
@@ -5,7 +5,7 @@
   "description": "Knurling Icon",
   "import_from": "terra-icon/lib/icon/IconKnurling",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconLast.json
+++ b/kaiju/icons/IconLast.json
@@ -5,7 +5,7 @@
   "description": "Last Icon",
   "import_from": "terra-icon/lib/icon/IconLast",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconLeft.json
+++ b/kaiju/icons/IconLeft.json
@@ -5,7 +5,7 @@
   "description": "Left Icon",
   "import_from": "terra-icon/lib/icon/IconLeft",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconLeftPane.json
+++ b/kaiju/icons/IconLeftPane.json
@@ -5,7 +5,7 @@
   "description": "Left Pane Icon",
   "import_from": "terra-icon/lib/icon/IconLeftPane",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconLightbulb.json
+++ b/kaiju/icons/IconLightbulb.json
@@ -5,7 +5,7 @@
   "description": "Lightbulb Icon",
   "import_from": "terra-icon/lib/icon/IconLightbulb",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconLink.json
+++ b/kaiju/icons/IconLink.json
@@ -5,7 +5,7 @@
   "description": "Link Icon",
   "import_from": "terra-icon/lib/icon/IconLink",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconList.json
+++ b/kaiju/icons/IconList.json
@@ -5,7 +5,7 @@
   "description": "List Icon",
   "import_from": "terra-icon/lib/icon/IconList",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconLookback.json
+++ b/kaiju/icons/IconLookback.json
@@ -5,7 +5,7 @@
   "description": "Lookback Icon",
   "import_from": "terra-icon/lib/icon/IconLookback",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconLow.json
+++ b/kaiju/icons/IconLow.json
@@ -5,7 +5,7 @@
   "description": "Low Icon",
   "import_from": "terra-icon/lib/icon/IconLow",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMax.json
+++ b/kaiju/icons/IconMax.json
@@ -5,7 +5,7 @@
   "description": "Max Icon",
   "import_from": "terra-icon/lib/icon/IconMax",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMaximize.json
+++ b/kaiju/icons/IconMaximize.json
@@ -5,7 +5,7 @@
   "description": "Maximize Icon",
   "import_from": "terra-icon/lib/icon/IconMaximize",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMenu.json
+++ b/kaiju/icons/IconMenu.json
@@ -5,7 +5,7 @@
   "description": "Menu Icon",
   "import_from": "terra-icon/lib/icon/IconMenu",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMerge.json
+++ b/kaiju/icons/IconMerge.json
@@ -5,7 +5,7 @@
   "description": "Merge Icon",
   "import_from": "terra-icon/lib/icon/IconMerge",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMicrophone.json
+++ b/kaiju/icons/IconMicrophone.json
@@ -5,7 +5,7 @@
   "description": "Microphone Icon",
   "import_from": "terra-icon/lib/icon/IconMicrophone",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMicrophoneDisabled.json
+++ b/kaiju/icons/IconMicrophoneDisabled.json
@@ -5,7 +5,7 @@
   "description": "Microphone Disabled Icon",
   "import_from": "terra-icon/lib/icon/IconMicrophoneDisabled",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMin.json
+++ b/kaiju/icons/IconMin.json
@@ -5,7 +5,7 @@
   "description": "Min Icon",
   "import_from": "terra-icon/lib/icon/IconMin",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMinimize.json
+++ b/kaiju/icons/IconMinimize.json
@@ -5,7 +5,7 @@
   "description": "Minimize Icon",
   "import_from": "terra-icon/lib/icon/IconMinimize",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMinus.json
+++ b/kaiju/icons/IconMinus.json
@@ -5,7 +5,7 @@
   "description": "Minus Icon",
   "import_from": "terra-icon/lib/icon/IconMinus",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconMissedCall.json
+++ b/kaiju/icons/IconMissedCall.json
@@ -5,7 +5,7 @@
   "description": "Missed Call Icon",
   "import_from": "terra-icon/lib/icon/IconMissedCall",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconModerate.json
+++ b/kaiju/icons/IconModerate.json
@@ -5,7 +5,7 @@
   "description": "Moderate Icon",
   "import_from": "terra-icon/lib/icon/IconModerate",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconModified.json
+++ b/kaiju/icons/IconModified.json
@@ -5,7 +5,7 @@
   "description": "Modified Icon",
   "import_from": "terra-icon/lib/icon/IconModified",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconNext.json
+++ b/kaiju/icons/IconNext.json
@@ -5,7 +5,7 @@
   "description": "Next Icon",
   "import_from": "terra-icon/lib/icon/IconNext",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconNoRisk.json
+++ b/kaiju/icons/IconNoRisk.json
@@ -5,7 +5,7 @@
   "description": "No Risk Icon",
   "import_from": "terra-icon/lib/icon/IconNoRisk",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconNoSignal.json
+++ b/kaiju/icons/IconNoSignal.json
@@ -5,7 +5,7 @@
   "description": "No Signal Icon",
   "import_from": "terra-icon/lib/icon/IconNoSignal",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconNotMet.json
+++ b/kaiju/icons/IconNotMet.json
@@ -5,7 +5,7 @@
   "description": "Not Met Icon",
   "import_from": "terra-icon/lib/icon/IconNotMet",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconNotification.json
+++ b/kaiju/icons/IconNotification.json
@@ -5,7 +5,7 @@
   "description": "Notification Icon",
   "import_from": "terra-icon/lib/icon/IconNotification",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconNotificationOff.json
+++ b/kaiju/icons/IconNotificationOff.json
@@ -5,7 +5,7 @@
   "description": "Notification Off Icon",
   "import_from": "terra-icon/lib/icon/IconNotificationOff",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconOutgoingCall.json
+++ b/kaiju/icons/IconOutgoingCall.json
@@ -5,7 +5,7 @@
   "description": "Outgoing Call Icon",
   "import_from": "terra-icon/lib/icon/IconOutgoingCall",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconOverDue.json
+++ b/kaiju/icons/IconOverDue.json
@@ -5,7 +5,7 @@
   "description": "Over Due Icon",
   "import_from": "terra-icon/lib/icon/IconOverDue",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPadlock.json
+++ b/kaiju/icons/IconPadlock.json
@@ -5,7 +5,7 @@
   "description": "Padlock Icon",
   "import_from": "terra-icon/lib/icon/IconPadlock",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPanelLeft.json
+++ b/kaiju/icons/IconPanelLeft.json
@@ -5,7 +5,7 @@
   "description": "Panel Left Icon",
   "import_from": "terra-icon/lib/icon/IconPanelLeft",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPanelRight.json
+++ b/kaiju/icons/IconPanelRight.json
@@ -5,7 +5,7 @@
   "description": "Panel Right Icon",
   "import_from": "terra-icon/lib/icon/IconPanelRight",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPaperFolded.json
+++ b/kaiju/icons/IconPaperFolded.json
@@ -5,7 +5,7 @@
   "description": "Paper Folded Icon",
   "import_from": "terra-icon/lib/icon/IconPaperFolded",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPaperPencil.json
+++ b/kaiju/icons/IconPaperPencil.json
@@ -5,7 +5,7 @@
   "description": "Paper Pencil Icon",
   "import_from": "terra-icon/lib/icon/IconPaperPencil",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPause.json
+++ b/kaiju/icons/IconPause.json
@@ -5,7 +5,7 @@
   "description": "Pause Icon",
   "import_from": "terra-icon/lib/icon/IconPause",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPending.json
+++ b/kaiju/icons/IconPending.json
@@ -5,7 +5,7 @@
   "description": "Pending Icon",
   "import_from": "terra-icon/lib/icon/IconPending",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPerson.json
+++ b/kaiju/icons/IconPerson.json
@@ -5,7 +5,7 @@
   "description": "Person Icon",
   "import_from": "terra-icon/lib/icon/IconPerson",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPersonHospital.json
+++ b/kaiju/icons/IconPersonHospital.json
@@ -5,7 +5,7 @@
   "description": "Person Hospital Icon",
   "import_from": "terra-icon/lib/icon/IconPersonHospital",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPersonnelPerson.json
+++ b/kaiju/icons/IconPersonnelPerson.json
@@ -5,7 +5,7 @@
   "description": "Personnel Person Icon",
   "import_from": "terra-icon/lib/icon/IconPersonnelPerson",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPharmacyReject.json
+++ b/kaiju/icons/IconPharmacyReject.json
@@ -5,7 +5,7 @@
   "description": "Pharmacy Reject Icon",
   "import_from": "terra-icon/lib/icon/IconPharmacyReject",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPharmacyReview.json
+++ b/kaiju/icons/IconPharmacyReview.json
@@ -5,7 +5,7 @@
   "description": "Pharmacy Review Icon",
   "import_from": "terra-icon/lib/icon/IconPharmacyReview",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPhone.json
+++ b/kaiju/icons/IconPhone.json
@@ -5,7 +5,7 @@
   "description": "Phone Icon",
   "import_from": "terra-icon/lib/icon/IconPhone",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPhoneDown.json
+++ b/kaiju/icons/IconPhoneDown.json
@@ -5,7 +5,7 @@
   "description": "Phone Down Icon",
   "import_from": "terra-icon/lib/icon/IconPhoneDown",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPill.json
+++ b/kaiju/icons/IconPill.json
@@ -5,7 +5,7 @@
   "description": "Pill Icon",
   "import_from": "terra-icon/lib/icon/IconPill",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPinDiagonal.json
+++ b/kaiju/icons/IconPinDiagonal.json
@@ -5,7 +5,7 @@
   "description": "Pin Diagonal Icon",
   "import_from": "terra-icon/lib/icon/IconPinDiagonal",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPinDown.json
+++ b/kaiju/icons/IconPinDown.json
@@ -5,7 +5,7 @@
   "description": "Pin Down Icon",
   "import_from": "terra-icon/lib/icon/IconPinDown",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPrevious.json
+++ b/kaiju/icons/IconPrevious.json
@@ -5,7 +5,7 @@
   "description": "Previous Icon",
   "import_from": "terra-icon/lib/icon/IconPrevious",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconPrinter.json
+++ b/kaiju/icons/IconPrinter.json
@@ -5,7 +5,7 @@
   "description": "Printer Icon",
   "import_from": "terra-icon/lib/icon/IconPrinter",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconProjects.json
+++ b/kaiju/icons/IconProjects.json
@@ -5,7 +5,7 @@
   "description": "Projects Icon",
   "import_from": "terra-icon/lib/icon/IconProjects",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconProtocol.json
+++ b/kaiju/icons/IconProtocol.json
@@ -5,7 +5,7 @@
   "description": "Protocol Icon",
   "import_from": "terra-icon/lib/icon/IconProtocol",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconProvider.json
+++ b/kaiju/icons/IconProvider.json
@@ -5,7 +5,7 @@
   "description": "Provider Icon",
   "import_from": "terra-icon/lib/icon/IconProvider",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconQuestion.json
+++ b/kaiju/icons/IconQuestion.json
@@ -5,7 +5,7 @@
   "description": "Question Icon",
   "import_from": "terra-icon/lib/icon/IconQuestion",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconQuestionOutline.json
+++ b/kaiju/icons/IconQuestionOutline.json
@@ -5,7 +5,7 @@
   "description": "Question Outline Icon",
   "import_from": "terra-icon/lib/icon/IconQuestionOutline",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconRecurringEvent.json
+++ b/kaiju/icons/IconRecurringEvent.json
@@ -5,7 +5,7 @@
   "description": "Recurring Event Icon",
   "import_from": "terra-icon/lib/icon/IconRecurringEvent",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconRefresh.json
+++ b/kaiju/icons/IconRefresh.json
@@ -5,7 +5,7 @@
   "description": "Refresh Icon",
   "import_from": "terra-icon/lib/icon/IconRefresh",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconReload.json
+++ b/kaiju/icons/IconReload.json
@@ -5,7 +5,7 @@
   "description": "Reload Icon",
   "import_from": "terra-icon/lib/icon/IconReload",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconReply.json
+++ b/kaiju/icons/IconReply.json
@@ -5,7 +5,7 @@
   "description": "Reply Icon",
   "import_from": "terra-icon/lib/icon/IconReply",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconReplyAll.json
+++ b/kaiju/icons/IconReplyAll.json
@@ -5,7 +5,7 @@
   "description": "Reply All Icon",
   "import_from": "terra-icon/lib/icon/IconReplyAll",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconRequired.json
+++ b/kaiju/icons/IconRequired.json
@@ -5,7 +5,7 @@
   "description": "Required Icon",
   "import_from": "terra-icon/lib/icon/IconRequired",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconRight.json
+++ b/kaiju/icons/IconRight.json
@@ -5,7 +5,7 @@
   "description": "Right Icon",
   "import_from": "terra-icon/lib/icon/IconRight",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconRotateLeft.json
+++ b/kaiju/icons/IconRotateLeft.json
@@ -5,7 +5,7 @@
   "description": "Rotate Left Icon",
   "import_from": "terra-icon/lib/icon/IconRotateLeft",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconRotateRight.json
+++ b/kaiju/icons/IconRotateRight.json
@@ -5,7 +5,7 @@
   "description": "Rotate Right Icon",
   "import_from": "terra-icon/lib/icon/IconRotateRight",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSave.json
+++ b/kaiju/icons/IconSave.json
@@ -5,7 +5,7 @@
   "description": "Save Icon",
   "import_from": "terra-icon/lib/icon/IconSave",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconScheduled.json
+++ b/kaiju/icons/IconScheduled.json
@@ -5,7 +5,7 @@
   "description": "Scheduled Icon",
   "import_from": "terra-icon/lib/icon/IconScheduled",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconScratchPad.json
+++ b/kaiju/icons/IconScratchPad.json
@@ -5,7 +5,7 @@
   "description": "Scratch Pad Icon",
   "import_from": "terra-icon/lib/icon/IconScratchPad",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSearch.json
+++ b/kaiju/icons/IconSearch.json
@@ -5,7 +5,7 @@
   "description": "Search Icon",
   "import_from": "terra-icon/lib/icon/IconSearch",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSend.json
+++ b/kaiju/icons/IconSend.json
@@ -5,7 +5,7 @@
   "description": "Send Icon",
   "import_from": "terra-icon/lib/icon/IconSend",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSeparate.json
+++ b/kaiju/icons/IconSeparate.json
@@ -5,7 +5,7 @@
   "description": "Separate Icon",
   "import_from": "terra-icon/lib/icon/IconSeparate",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSettings.json
+++ b/kaiju/icons/IconSettings.json
@@ -5,7 +5,7 @@
   "description": "Settings Icon",
   "import_from": "terra-icon/lib/icon/IconSettings",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSortAscending.json
+++ b/kaiju/icons/IconSortAscending.json
@@ -5,7 +5,7 @@
   "description": "Sort Ascending Icon",
   "import_from": "terra-icon/lib/icon/IconSortAscending",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSortDescending.json
+++ b/kaiju/icons/IconSortDescending.json
@@ -5,7 +5,7 @@
   "description": "Sort Descending Icon",
   "import_from": "terra-icon/lib/icon/IconSortDescending",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSpinner.json
+++ b/kaiju/icons/IconSpinner.json
@@ -5,7 +5,7 @@
   "description": "Spinner Icon",
   "import_from": "terra-icon/lib/icon/IconSpinner",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSuccess.json
+++ b/kaiju/icons/IconSuccess.json
@@ -5,7 +5,7 @@
   "description": "Success Icon",
   "import_from": "terra-icon/lib/icon/IconSuccess",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSuccessInverse.json
+++ b/kaiju/icons/IconSuccessInverse.json
@@ -5,7 +5,7 @@
   "description": "Success Inverse Icon",
   "import_from": "terra-icon/lib/icon/IconSuccessInverse",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconSwap.json
+++ b/kaiju/icons/IconSwap.json
@@ -5,7 +5,7 @@
   "description": "Swap Icon",
   "import_from": "terra-icon/lib/icon/IconSwap",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconTable.json
+++ b/kaiju/icons/IconTable.json
@@ -5,7 +5,7 @@
   "description": "Table Icon",
   "import_from": "terra-icon/lib/icon/IconTable",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconTag.json
+++ b/kaiju/icons/IconTag.json
@@ -5,7 +5,7 @@
   "description": "Tag Icon",
   "import_from": "terra-icon/lib/icon/IconTag",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconTile.json
+++ b/kaiju/icons/IconTile.json
@@ -5,7 +5,7 @@
   "description": "Tile Icon",
   "import_from": "terra-icon/lib/icon/IconTile",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconTrash.json
+++ b/kaiju/icons/IconTrash.json
@@ -5,7 +5,7 @@
   "description": "Trash Icon",
   "import_from": "terra-icon/lib/icon/IconTrash",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconTreemap.json
+++ b/kaiju/icons/IconTreemap.json
@@ -5,7 +5,7 @@
   "description": "Treemap Icon",
   "import_from": "terra-icon/lib/icon/IconTreemap",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconTrophy.json
+++ b/kaiju/icons/IconTrophy.json
@@ -5,7 +5,7 @@
   "description": "Trophy Icon",
   "import_from": "terra-icon/lib/icon/IconTrophy",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUnavailable.json
+++ b/kaiju/icons/IconUnavailable.json
@@ -5,7 +5,7 @@
   "description": "Unavailable Icon",
   "import_from": "terra-icon/lib/icon/IconUnavailable",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUnexpected.json
+++ b/kaiju/icons/IconUnexpected.json
@@ -5,7 +5,7 @@
   "description": "Unexpected Icon",
   "import_from": "terra-icon/lib/icon/IconUnexpected",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUnknown.json
+++ b/kaiju/icons/IconUnknown.json
@@ -5,7 +5,7 @@
   "description": "Unknown Icon",
   "import_from": "terra-icon/lib/icon/IconUnknown",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUnlock.json
+++ b/kaiju/icons/IconUnlock.json
@@ -5,7 +5,7 @@
   "description": "Unlock Icon",
   "import_from": "terra-icon/lib/icon/IconUnlock",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUnread.json
+++ b/kaiju/icons/IconUnread.json
@@ -5,7 +5,7 @@
   "description": "Unread Icon",
   "import_from": "terra-icon/lib/icon/IconUnread",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUnspecified.json
+++ b/kaiju/icons/IconUnspecified.json
@@ -5,7 +5,7 @@
   "description": "Unspecified Icon",
   "import_from": "terra-icon/lib/icon/IconUnspecified",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUp.json
+++ b/kaiju/icons/IconUp.json
@@ -5,7 +5,7 @@
   "description": "Up Icon",
   "import_from": "terra-icon/lib/icon/IconUp",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUpload.json
+++ b/kaiju/icons/IconUpload.json
@@ -5,7 +5,7 @@
   "description": "Upload Icon",
   "import_from": "terra-icon/lib/icon/IconUpload",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconUsers.json
+++ b/kaiju/icons/IconUsers.json
@@ -5,7 +5,7 @@
   "description": "Users Icon",
   "import_from": "terra-icon/lib/icon/IconUsers",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconVideoCamera.json
+++ b/kaiju/icons/IconVideoCamera.json
@@ -5,7 +5,7 @@
   "description": "Video Camera Icon",
   "import_from": "terra-icon/lib/icon/IconVideoCamera",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconVideoCameraDisabled.json
+++ b/kaiju/icons/IconVideoCameraDisabled.json
@@ -5,7 +5,7 @@
   "description": "Video Camera Disabled Icon",
   "import_from": "terra-icon/lib/icon/IconVideoCameraDisabled",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconVisualization.json
+++ b/kaiju/icons/IconVisualization.json
@@ -5,7 +5,7 @@
   "description": "Visualization Icon",
   "import_from": "terra-icon/lib/icon/IconVisualization",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconWarning.json
+++ b/kaiju/icons/IconWarning.json
@@ -5,7 +5,7 @@
   "description": "Warning Icon",
   "import_from": "terra-icon/lib/icon/IconWarning",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconZoomIn.json
+++ b/kaiju/icons/IconZoomIn.json
@@ -5,7 +5,7 @@
   "description": "Zoom In Icon",
   "import_from": "terra-icon/lib/icon/IconZoomIn",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/kaiju/icons/IconZoomOut.json
+++ b/kaiju/icons/IconZoomOut.json
@@ -5,7 +5,7 @@
   "description": "Zoom Out Icon",
   "import_from": "terra-icon/lib/icon/IconZoomOut",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"

--- a/scripts/kaiju/template.json
+++ b/scripts/kaiju/template.json
@@ -5,7 +5,7 @@
   "description": "",
   "import_from": "",
   "group": "Atoms::Icons",
-  "documentation": "http://engineering.cerner.com/terra-ui/#/site/components/core/site/icon/index",
+  "documentation": "http://engineering.cerner.com/terra-ui/#/components/terra-icon/icon",
   "properties": {
     "isBidi": {
       "type": "Bool"


### PR DESCRIPTION
### Summary
Updated the documentation links to match the recently deployed changes in terra-ui site.

Thanks for contributing to terra-kaiju-plugin.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
