### PR TITLE
Update - Remove Hyperlink href attribute

### DIFF
--- a/kaiju/Hyperlink.json
+++ b/kaiju/Hyperlink.json
@@ -14,10 +14,6 @@
       "type": "Bool",
       "display": "Underline hidden"
     },
-    "href": {
-      "type": "String",
-      "display": "Href"
-    },
     "variant": {
       "type": "String",
       "display": "Variant",


### PR DESCRIPTION
### Summary
Kaiju prevents redirects outside of its domain as a security precaution. This change removes the href from the Hyperlink to prevent users from erroring out their workspaces. 

Thanks for contributing to terra-kaiju-plugin.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
