### PR TITLE
Update Grid Example

### DIFF
--- a/kaiju/Grid.json
+++ b/kaiju/Grid.json
@@ -19,19 +19,19 @@
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               },
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               },
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               }
             ]
@@ -44,19 +44,19 @@
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               },
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               },
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               }
             ]
@@ -69,19 +69,19 @@
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               },
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               },
               {
                 "type": "terra-grid::Column",
                 "props": {
-                  "col": "4"
+                  "tiny": "4"
                 }
               }
             ]


### PR DESCRIPTION
### Summary

Update the Grid examples to use the `tiny` prop. `col` has been removed.

Thanks for contributing to terra-kaiju-plugin.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
